### PR TITLE
Update dependencies related to "npm audit"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -716,98 +716,98 @@
             }
         },
         "@ethersproject/abstract-provider": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.1.0.tgz",
-            "integrity": "sha512-8dJUnT8VNvPwWhYIau4dwp7qe1g+KgdRm4XTWvjkI9gAT2zZa90WF5ApdZ3vl1r6NDmnn6vUVvyphClRZRteTQ==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.2.0.tgz",
+            "integrity": "sha512-Xi7Pt+CulRijc/vskBGIaYMEhafKjoNx8y4RNj/dnSpXHXScOJUSTtypqGBUngZddRbcwZGbHwEr6DZoKZwIZA==",
             "requires": {
-                "@ethersproject/bignumber": "^5.1.0",
-                "@ethersproject/bytes": "^5.1.0",
-                "@ethersproject/logger": "^5.1.0",
-                "@ethersproject/networks": "^5.1.0",
-                "@ethersproject/properties": "^5.1.0",
-                "@ethersproject/transactions": "^5.1.0",
-                "@ethersproject/web": "^5.1.0"
+                "@ethersproject/bignumber": "^5.2.0",
+                "@ethersproject/bytes": "^5.2.0",
+                "@ethersproject/logger": "^5.2.0",
+                "@ethersproject/networks": "^5.2.0",
+                "@ethersproject/properties": "^5.2.0",
+                "@ethersproject/transactions": "^5.2.0",
+                "@ethersproject/web": "^5.2.0"
             }
         },
         "@ethersproject/abstract-signer": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.1.0.tgz",
-            "integrity": "sha512-qQDMkjGZSSJSKl6AnfTgmz9FSnzq3iEoEbHTYwjDlEAv+LNP7zd4ixCcVWlWyk+2siud856M5CRhAmPdupeN9w==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.2.0.tgz",
+            "integrity": "sha512-JTXzLUrtoxpOEq1ecH86U7tstkEa9POKAGbGBb+gicbjGgzYYkLR4/LD83SX2/JNWvtYyY8t5errt5ehiy1gxQ==",
             "requires": {
-                "@ethersproject/abstract-provider": "^5.1.0",
-                "@ethersproject/bignumber": "^5.1.0",
-                "@ethersproject/bytes": "^5.1.0",
-                "@ethersproject/logger": "^5.1.0",
-                "@ethersproject/properties": "^5.1.0"
+                "@ethersproject/abstract-provider": "^5.2.0",
+                "@ethersproject/bignumber": "^5.2.0",
+                "@ethersproject/bytes": "^5.2.0",
+                "@ethersproject/logger": "^5.2.0",
+                "@ethersproject/properties": "^5.2.0"
             }
         },
         "@ethersproject/address": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.1.0.tgz",
-            "integrity": "sha512-rfWQR12eHn2cpstCFS4RF7oGjfbkZb0oqep+BfrT+gWEGWG2IowJvIsacPOvzyS1jhNF4MQ4BS59B04Mbovteg==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.2.0.tgz",
+            "integrity": "sha512-2YfZlalWefOEfnr/CdqKRrgMgbKidYc+zG4/ilxSdcryZSux3eBU5/5btAT/hSiaHipUjd8UrWK8esCBHU6QNQ==",
             "requires": {
-                "@ethersproject/bignumber": "^5.1.0",
-                "@ethersproject/bytes": "^5.1.0",
-                "@ethersproject/keccak256": "^5.1.0",
-                "@ethersproject/logger": "^5.1.0",
-                "@ethersproject/rlp": "^5.1.0"
+                "@ethersproject/bignumber": "^5.2.0",
+                "@ethersproject/bytes": "^5.2.0",
+                "@ethersproject/keccak256": "^5.2.0",
+                "@ethersproject/logger": "^5.2.0",
+                "@ethersproject/rlp": "^5.2.0"
             }
         },
         "@ethersproject/base64": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.1.0.tgz",
-            "integrity": "sha512-npD1bLvK4Bcxz+m4EMkx+F8Rd7CnqS9DYnhNu0/GlQBXhWjvfoAZzk5HJ0f1qeyp8d+A86PTuzLOGOXf4/CN8g==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.2.0.tgz",
+            "integrity": "sha512-D9wOvRE90QBI+yFsKMv0hnANiMzf40Xicq9JZbV9XYzh7srImmwmMcReU2wHjOs9FtEgSJo51Tt+sI1dKPYKDg==",
             "requires": {
-                "@ethersproject/bytes": "^5.1.0"
+                "@ethersproject/bytes": "^5.2.0"
             }
         },
         "@ethersproject/bignumber": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.1.0.tgz",
-            "integrity": "sha512-wUvQlhTjPjFXIdLPOuTrFeQmSa6Wvls1bGXQNQWvB/SEn1NsTCE8PmumIEZxmOPjSHl1eV2uyHP5jBm5Cgj92Q==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.2.0.tgz",
+            "integrity": "sha512-+MNQTxwV7GEiA4NH/i51UqQ+lY36O0rxPdV+0qzjFSySiyBlJpLk6aaa4UTvKmYWlI7YKZm6vuyCENeYn7qAOw==",
             "requires": {
-                "@ethersproject/bytes": "^5.1.0",
-                "@ethersproject/logger": "^5.1.0",
+                "@ethersproject/bytes": "^5.2.0",
+                "@ethersproject/logger": "^5.2.0",
                 "bn.js": "^4.4.0"
             }
         },
         "@ethersproject/bytes": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.1.0.tgz",
-            "integrity": "sha512-sGTxb+LVjFxJcJeUswAIK6ncgOrh3D8c192iEJd7mLr95V6du119rRfYT/b87WPkZ5I3gRBUYIYXtdgCWACe8g==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.2.0.tgz",
+            "integrity": "sha512-O1CRpvJDnRTB47vvW8vyqojUZxVookb4LJv/s06TotriU3Xje5WFvlvXJu1yTchtxTz9BbvJw0lFXKpyO6Dn7w==",
             "requires": {
-                "@ethersproject/logger": "^5.1.0"
+                "@ethersproject/logger": "^5.2.0"
             }
         },
         "@ethersproject/constants": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.1.0.tgz",
-            "integrity": "sha512-0/SuHrxc8R8k+JiLmJymxHJbojUDWBQqO+b+XFdwaP0jGzqC09YDy/CAlSZB6qHsBifY8X3I89HcK/oMqxRdBw==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.2.0.tgz",
+            "integrity": "sha512-p+34YG0KbHS20NGdE+Ic0M6egzd7cDvcfoO9RpaAgyAYm3V5gJVqL7UynS87yCt6O6Nlx6wRFboPiM5ctAr+jA==",
             "requires": {
-                "@ethersproject/bignumber": "^5.1.0"
+                "@ethersproject/bignumber": "^5.2.0"
             }
         },
         "@ethersproject/hash": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.1.0.tgz",
-            "integrity": "sha512-fNwry20yLLPpnRRwm3fBL+2ksgO+KMadxM44WJmRIoTKzy4269+rbq9KFoe2LTqq2CXJM2CE70beGaNrpuqflQ==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.2.0.tgz",
+            "integrity": "sha512-wEGry2HFFSssFiNEkFWMzj1vpdFv4rQlkBp41UfL6J58zKGNycoAWimokITDMk8p7548MKr27h48QfERnNKkRw==",
             "requires": {
-                "@ethersproject/abstract-signer": "^5.1.0",
-                "@ethersproject/address": "^5.1.0",
-                "@ethersproject/bignumber": "^5.1.0",
-                "@ethersproject/bytes": "^5.1.0",
-                "@ethersproject/keccak256": "^5.1.0",
-                "@ethersproject/logger": "^5.1.0",
-                "@ethersproject/properties": "^5.1.0",
-                "@ethersproject/strings": "^5.1.0"
+                "@ethersproject/abstract-signer": "^5.2.0",
+                "@ethersproject/address": "^5.2.0",
+                "@ethersproject/bignumber": "^5.2.0",
+                "@ethersproject/bytes": "^5.2.0",
+                "@ethersproject/keccak256": "^5.2.0",
+                "@ethersproject/logger": "^5.2.0",
+                "@ethersproject/properties": "^5.2.0",
+                "@ethersproject/strings": "^5.2.0"
             }
         },
         "@ethersproject/keccak256": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.1.0.tgz",
-            "integrity": "sha512-vrTB1W6AEYoadww5c9UyVJ2YcSiyIUTNDRccZIgwTmFFoSHwBtcvG1hqy9RzJ1T0bMdATbM9Hfx2mJ6H0i7Hig==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.2.0.tgz",
+            "integrity": "sha512-LqyxTwVANga5Y3L1yo184czW6b3PibabN8xyE/eOulQLLfXNrHHhwrOTpOhoVRWCICVCD/5SjQfwqTrczjS7jQ==",
             "requires": {
-                "@ethersproject/bytes": "^5.1.0",
+                "@ethersproject/bytes": "^5.2.0",
                 "js-sha3": "0.5.7"
             },
             "dependencies": {
@@ -819,83 +819,83 @@
             }
         },
         "@ethersproject/logger": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.1.0.tgz",
-            "integrity": "sha512-wtUaD1lBX10HBXjjKV9VHCBnTdUaKQnQ2XSET1ezglqLdPdllNOIlLfhyCRqXm5xwcjExVI5ETokOYfjPtaAlw=="
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.2.0.tgz",
+            "integrity": "sha512-dPZ6/E3YiArgG8dI/spGkaRDry7YZpCntf4gm/c6SI8Mbqiihd7q3nuLN5VvDap/0K3xm3RE1AIUOcUwwh2ezQ=="
         },
         "@ethersproject/networks": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.1.0.tgz",
-            "integrity": "sha512-A/NIrIED/G/IgU1XUukOA3WcFRxn2I4O5GxsYGA5nFlIi+UZWdGojs85I1VXkR1gX9eFnDXzjE6OtbgZHjFhIA==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.2.0.tgz",
+            "integrity": "sha512-q+htMgq7wQoEnjlkdHM6t1sktKxNbEB/F6DQBPNwru7KpQ1R0n0UTIXJB8Rb7lSnvjqcAQ40X3iVqm94NJfYDw==",
             "requires": {
-                "@ethersproject/logger": "^5.1.0"
+                "@ethersproject/logger": "^5.2.0"
             }
         },
         "@ethersproject/properties": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.1.0.tgz",
-            "integrity": "sha512-519KKTwgmH42AQL3+GFV3SX6khYEfHsvI6v8HYejlkigSDuqttdgVygFTDsGlofNFchhDwuclrxQnD5B0YLNMg==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.2.0.tgz",
+            "integrity": "sha512-oNFkzcoGwXXV+/Yp/MLcDLrL/2i360XIy2YN9yRZJPnIbLwjroFNLiRzLs6PyPw1D09Xs8OcPR1/nHv6xDKE2A==",
             "requires": {
-                "@ethersproject/logger": "^5.1.0"
+                "@ethersproject/logger": "^5.2.0"
             }
         },
         "@ethersproject/rlp": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.1.0.tgz",
-            "integrity": "sha512-vDTyHIwNPrecy55gKGZ47eJZhBm8LLBxihzi5ou+zrSvYTpkSTWRcKUlXFDFQVwfWB+P5PGyERAdiDEI76clxw==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.2.0.tgz",
+            "integrity": "sha512-RqGsELtPWxcFhOOhSr0lQ2hBNT9tBE08WK0tb6VQbCk97EpqkbgP8yXED9PZlWMiRGchJTw6S+ExzK62XMX/fw==",
             "requires": {
-                "@ethersproject/bytes": "^5.1.0",
-                "@ethersproject/logger": "^5.1.0"
+                "@ethersproject/bytes": "^5.2.0",
+                "@ethersproject/logger": "^5.2.0"
             }
         },
         "@ethersproject/signing-key": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.1.0.tgz",
-            "integrity": "sha512-tE5LFlbmdObG8bY04NpuwPWSRPgEswfxweAI1sH7TbP0ml1elNfqcq7ii/3AvIN05i5U0Pkm3Tf8bramt8MmLw==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.2.0.tgz",
+            "integrity": "sha512-9A+dVSkrVAPuhJnWqLWV/NkKi/KB4iagTKEuojfuApUfeIHEhpwQ0Jx3cBimk7qWISSSKdgiAmIqpvVtZ5FEkg==",
             "requires": {
-                "@ethersproject/bytes": "^5.1.0",
-                "@ethersproject/logger": "^5.1.0",
-                "@ethersproject/properties": "^5.1.0",
+                "@ethersproject/bytes": "^5.2.0",
+                "@ethersproject/logger": "^5.2.0",
+                "@ethersproject/properties": "^5.2.0",
                 "bn.js": "^4.4.0",
                 "elliptic": "6.5.4"
             }
         },
         "@ethersproject/strings": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.1.0.tgz",
-            "integrity": "sha512-perBZy0RrmmL0ejiFGUOlBVjMsUceqLut3OBP3zP96LhiJWWbS8u1NqQVgN4/Gyrbziuda66DxiQocXhsvx+Sw==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.2.0.tgz",
+            "integrity": "sha512-RmjX800wRYKgrzo2ZCSlA8OCQYyq4+M46VgjSVDVyYkLZctBXC3epqlppDA24R7eo856KNbXqezZsMnHT+sSuA==",
             "requires": {
-                "@ethersproject/bytes": "^5.1.0",
-                "@ethersproject/constants": "^5.1.0",
-                "@ethersproject/logger": "^5.1.0"
+                "@ethersproject/bytes": "^5.2.0",
+                "@ethersproject/constants": "^5.2.0",
+                "@ethersproject/logger": "^5.2.0"
             }
         },
         "@ethersproject/transactions": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.1.0.tgz",
-            "integrity": "sha512-s10crRLZEA0Bgv6FGEl/AKkTw9f+RVUrlWDX1rHnD4ZncPFeiV2AJr4nT7QSUhxJdFPvjyKRDb3nEH27dIqcPQ==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.2.0.tgz",
+            "integrity": "sha512-QrGbhGYsouNNclUp3tWMbckMsuXJTOsA56kT3BuRrLlXJcUH7myIihajXdSfKcyJsvHJPrGZP+U3TKh+sLzZtg==",
             "requires": {
-                "@ethersproject/address": "^5.1.0",
-                "@ethersproject/bignumber": "^5.1.0",
-                "@ethersproject/bytes": "^5.1.0",
-                "@ethersproject/constants": "^5.1.0",
-                "@ethersproject/keccak256": "^5.1.0",
-                "@ethersproject/logger": "^5.1.0",
-                "@ethersproject/properties": "^5.1.0",
-                "@ethersproject/rlp": "^5.1.0",
-                "@ethersproject/signing-key": "^5.1.0"
+                "@ethersproject/address": "^5.2.0",
+                "@ethersproject/bignumber": "^5.2.0",
+                "@ethersproject/bytes": "^5.2.0",
+                "@ethersproject/constants": "^5.2.0",
+                "@ethersproject/keccak256": "^5.2.0",
+                "@ethersproject/logger": "^5.2.0",
+                "@ethersproject/properties": "^5.2.0",
+                "@ethersproject/rlp": "^5.2.0",
+                "@ethersproject/signing-key": "^5.2.0"
             }
         },
         "@ethersproject/web": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.1.0.tgz",
-            "integrity": "sha512-LTeluWgTq04+RNqAkVhpydPcRZK/kKxD2Vy7PYGrAD27ABO9kTqTBKwiOuzTyAHKUQHfnvZbXmxBXJAGViSDcA==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.2.0.tgz",
+            "integrity": "sha512-mYb9qxGlOBFR2pR6t1CZczuqqX6r8RQGn7MtwrBciMex3cvA/qs+wbmcDgl+/OZY0Pco/ih6WHQRnVi+4sBeCQ==",
             "requires": {
-                "@ethersproject/base64": "^5.1.0",
-                "@ethersproject/bytes": "^5.1.0",
-                "@ethersproject/logger": "^5.1.0",
-                "@ethersproject/properties": "^5.1.0",
-                "@ethersproject/strings": "^5.1.0"
+                "@ethersproject/base64": "^5.2.0",
+                "@ethersproject/bytes": "^5.2.0",
+                "@ethersproject/logger": "^5.2.0",
+                "@ethersproject/properties": "^5.2.0",
+                "@ethersproject/strings": "^5.2.0"
             }
         },
         "@istanbuljs/load-nyc-config": {
@@ -2338,9 +2338,9 @@
             }
         },
         "@types/secp256k1": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@types/secp256k1/-/secp256k1-4.0.1.tgz",
-            "integrity": "sha512-+ZjSA8ELlOp8SlKi0YLB2tz9d5iPNEmOBd+8Rz21wTMdaXQIa9b6TEnD6l5qKOCypE7FSyPyck12qZJxSDNoog==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@types/secp256k1/-/secp256k1-4.0.2.tgz",
+            "integrity": "sha512-QMg+9v0bbNJ2peLuHRWxzmy0HRJIG6gFZNhaRSp7S3ggSbCCxiqQB2/ybvhXyhHOCequpNkrx7OavNhrWOsW0A==",
             "requires": {
                 "@types/node": "*"
             }
@@ -2687,11 +2687,6 @@
             "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
             "dev": true
         },
-        "array-filter": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-1.0.0.tgz",
-            "integrity": "sha1-uveeYubvTCpMC4MSMtr/7CUfnYM="
-        },
         "array-find-index": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
@@ -2784,12 +2779,9 @@
             "dev": true
         },
         "available-typed-arrays": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.2.tgz",
-            "integrity": "sha512-XWX3OX8Onv97LMk/ftVyBibpGwY5a8SmuxZPzeOxqmuEqUCOM9ZE+uIaD1VNJ5QnvU2UQusvmKbuM1FR8QWGfQ==",
-            "requires": {
-                "array-filter": "^1.0.0"
-            }
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.4.tgz",
+            "integrity": "sha512-SA5mXJWrId1TaQjfxUYghbqQ/hYioKmLJvPJyDuYRtXXenFNMjj4hSSt1Cf1xsuXSXrtxrVC5Ot4eU6cOtBDdA=="
         },
         "aws-sign2": {
             "version": "0.7.0",
@@ -3369,28 +3361,20 @@
                     "version": "5.2.1",
                     "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
                     "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
-                },
-                "string_decoder": {
-                    "version": "1.3.0",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-                    "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-                    "requires": {
-                        "safe-buffer": "~5.2.0"
-                    }
                 }
             }
         },
         "browserslist": {
-            "version": "4.16.3",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.3.tgz",
-            "integrity": "sha512-vIyhWmIkULaq04Gt93txdh+j02yX/JzlyhLYbV3YQCn/zvES3JnY7TifHHvvr1w5hTDluNKMkV05cs4vy8Q7sw==",
+            "version": "4.16.6",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.6.tgz",
+            "integrity": "sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==",
             "dev": true,
             "requires": {
-                "caniuse-lite": "^1.0.30001181",
-                "colorette": "^1.2.1",
-                "electron-to-chromium": "^1.3.649",
+                "caniuse-lite": "^1.0.30001219",
+                "colorette": "^1.2.2",
+                "electron-to-chromium": "^1.3.723",
                 "escalade": "^3.1.1",
-                "node-releases": "^1.1.70"
+                "node-releases": "^1.1.71"
             }
         },
         "bs-logger": {
@@ -3557,9 +3541,9 @@
             }
         },
         "caniuse-lite": {
-            "version": "1.0.30001208",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001208.tgz",
-            "integrity": "sha512-OE5UE4+nBOro8Dyvv0lfx+SRtfVIOM9uhKqFmJeUbGriqhhStgp1A0OyBpgy3OUF8AhYCT+PVwPC1gMl2ZcQMA==",
+            "version": "1.0.30001230",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001230.tgz",
+            "integrity": "sha512-5yBd5nWCBS+jWKTcHOzXwo5xzcj4ePE/yjtkZyUV1BTUmrBaA9MRGC+e7mxnqXSA90CmCA8L3eKLaSUkt099IQ==",
             "dev": true
         },
         "capture-exit": {
@@ -4533,9 +4517,9 @@
             "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
         },
         "electron-to-chromium": {
-            "version": "1.3.712",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.712.tgz",
-            "integrity": "sha512-3kRVibBeCM4vsgoHHGKHmPocLqtFAGTrebXxxtgKs87hNUzXrX2NuS3jnBys7IozCnw7viQlozxKkmty2KNfrw==",
+            "version": "1.3.739",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.739.tgz",
+            "integrity": "sha512-+LPJVRsN7hGZ9EIUUiWCpO7l4E3qBYHNadazlucBfsXBbccDFNKUBAgzE68FnkWGJPwD/AfKhSzL+G+Iqb8A4A==",
             "dev": true
         },
         "elliptic": {
@@ -4628,6 +4612,60 @@
             "requires": {
                 "accepts": "~1.3.7",
                 "escape-html": "~1.0.3"
+            }
+        },
+        "es-abstract": {
+            "version": "1.18.2",
+            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.2.tgz",
+            "integrity": "sha512-byRiNIQXE6HWNySaU6JohoNXzYgbBjztwFnBLUTiJmWXjaU9bSq3urQLUlNLQ292tc+gc07zYZXNZjaOoAX3sw==",
+            "requires": {
+                "call-bind": "^1.0.2",
+                "es-to-primitive": "^1.2.1",
+                "function-bind": "^1.1.1",
+                "get-intrinsic": "^1.1.1",
+                "has": "^1.0.3",
+                "has-symbols": "^1.0.2",
+                "is-callable": "^1.2.3",
+                "is-negative-zero": "^2.0.1",
+                "is-regex": "^1.1.3",
+                "is-string": "^1.0.6",
+                "object-inspect": "^1.10.3",
+                "object-keys": "^1.1.1",
+                "object.assign": "^4.1.2",
+                "string.prototype.trimend": "^1.0.4",
+                "string.prototype.trimstart": "^1.0.4",
+                "unbox-primitive": "^1.0.1"
+            },
+            "dependencies": {
+                "is-regex": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.3.tgz",
+                    "integrity": "sha512-qSVXFz28HM7y+IWX6vLCsexdlvzT1PJNFSBuaQLQ5o0IEw8UDYW6/2+eCMVyIsbM8CNLX2a/QWmSpyxYEHY7CQ==",
+                    "requires": {
+                        "call-bind": "^1.0.2",
+                        "has-symbols": "^1.0.2"
+                    }
+                },
+                "is-string": {
+                    "version": "1.0.6",
+                    "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.6.tgz",
+                    "integrity": "sha512-2gdzbKUuqtQ3lYNrUTQYoClPhm7oQu4UdpSZMp1/DGgkHBT8E2Z1l0yMdb6D4zNAxwDiMv8MdulKROJGNl0Q0w=="
+                },
+                "object-inspect": {
+                    "version": "1.10.3",
+                    "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.3.tgz",
+                    "integrity": "sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw=="
+                }
+            }
+        },
+        "es-to-primitive": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+            "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+            "requires": {
+                "is-callable": "^1.1.4",
+                "is-date-object": "^1.0.1",
+                "is-symbol": "^1.0.2"
             }
         },
         "es5-ext": {
@@ -5067,18 +5105,6 @@
                 "servify": "^0.1.12",
                 "ws": "^3.0.0",
                 "xhr-request-promise": "^0.1.2"
-            },
-            "dependencies": {
-                "ws": {
-                    "version": "3.3.3",
-                    "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
-                    "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
-                    "requires": {
-                        "async-limiter": "~1.0.0",
-                        "safe-buffer": "~5.1.0",
-                        "ultron": "~1.1.0"
-                    }
-                }
             }
         },
         "ethereum-bloom-filters": {
@@ -5943,7 +5969,6 @@
             "version": "9.6.0",
             "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
             "integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
-            "dev": true,
             "requires": {
                 "@sindresorhus/is": "^0.14.0",
                 "@szmarczak/http-timer": "^1.1.2",
@@ -5961,14 +5986,12 @@
                 "prepend-http": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
-                    "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
-                    "dev": true
+                    "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
                 },
                 "url-parse-lax": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
                     "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
-                    "dev": true,
                     "requires": {
                         "prepend-http": "^2.0.0"
                     }
@@ -6043,9 +6066,9 @@
             "integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw=="
         },
         "has-symbols": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
-            "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q="
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+            "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
         },
         "has-to-string-tag-x": {
             "version": "1.4.1",
@@ -6148,14 +6171,6 @@
                     "version": "5.2.1",
                     "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
                     "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
-                },
-                "string_decoder": {
-                    "version": "1.3.0",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-                    "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-                    "requires": {
-                        "safe-buffer": "~5.2.0"
-                    }
                 }
             }
         },
@@ -6179,9 +6194,9 @@
             }
         },
         "hosted-git-info": {
-            "version": "2.7.1",
-            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
-            "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
+            "version": "2.8.9",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+            "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
             "dev": true
         },
         "html-encoding-sniffer": {
@@ -6393,9 +6408,9 @@
             "dev": true
         },
         "is-bigint": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.1.tgz",
-            "integrity": "sha512-J0ELF4yHFxHy0cmSxZuheDOz2luOdVvqjwmEcj8H/L1JHeuEDSDbeRP+Dk9kFVk5RTFzbucJ2Kb9F7ixY2QaCg=="
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.2.tgz",
+            "integrity": "sha512-0JV5+SOCQkIdzjBK9buARcV804Ddu7A0Qet6sHi3FimE9ne6m4BGQZfRn+NZiXbBk4F4XmHfDZIipLj9pX8dSA=="
         },
         "is-binary-path": {
             "version": "2.1.0",
@@ -6419,6 +6434,11 @@
             "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
             "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
             "dev": true
+        },
+        "is-callable": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
+            "integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ=="
         },
         "is-ci": {
             "version": "2.0.0",
@@ -6458,9 +6478,9 @@
             }
         },
         "is-date-object": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-            "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.4.tgz",
+            "integrity": "sha512-/b4ZVsG7Z5XVtIxs/h9W8nvfLgSAyKYdtGWQLbqy6jA1icmgjf8WCoTKgeS4wy5tYaPePouzFMANbnj94c2Z+A=="
         },
         "is-descriptor": {
             "version": "0.1.6",
@@ -6533,9 +6553,9 @@
             "dev": true
         },
         "is-generator-function": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.8.tgz",
-            "integrity": "sha512-2Omr/twNtufVZFr1GhxjOMFPAj2sjc/dKaIqBhvo4qciXfJmITGH6ZGd8eZYNHza8t1y0e01AuqRhJwfWp26WQ=="
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.9.tgz",
+            "integrity": "sha512-ZJ34p1uvIfptHCN7sFTjGibB9/oBg17sHqzDLfuwhvmN/qLVvIQXRQ8licZQ35WJ8KuEQt/etnnzQFI9C9Ue/A=="
         },
         "is-glob": {
             "version": "4.0.1",
@@ -6657,11 +6677,11 @@
             "integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ=="
         },
         "is-symbol": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
-            "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
+            "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
             "requires": {
-                "has-symbols": "^1.0.0"
+                "has-symbols": "^1.0.2"
             }
         },
         "is-typed-array": {
@@ -6674,65 +6694,6 @@
                 "es-abstract": "^1.18.0-next.2",
                 "foreach": "^2.0.5",
                 "has-symbols": "^1.0.1"
-            },
-            "dependencies": {
-                "es-abstract": {
-                    "version": "1.18.0",
-                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0.tgz",
-                    "integrity": "sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==",
-                    "requires": {
-                        "call-bind": "^1.0.2",
-                        "es-to-primitive": "^1.2.1",
-                        "function-bind": "^1.1.1",
-                        "get-intrinsic": "^1.1.1",
-                        "has": "^1.0.3",
-                        "has-symbols": "^1.0.2",
-                        "is-callable": "^1.2.3",
-                        "is-negative-zero": "^2.0.1",
-                        "is-regex": "^1.1.2",
-                        "is-string": "^1.0.5",
-                        "object-inspect": "^1.9.0",
-                        "object-keys": "^1.1.1",
-                        "object.assign": "^4.1.2",
-                        "string.prototype.trimend": "^1.0.4",
-                        "string.prototype.trimstart": "^1.0.4",
-                        "unbox-primitive": "^1.0.0"
-                    }
-                },
-                "es-to-primitive": {
-                    "version": "1.2.1",
-                    "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
-                    "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-                    "requires": {
-                        "is-callable": "^1.1.4",
-                        "is-date-object": "^1.0.1",
-                        "is-symbol": "^1.0.2"
-                    }
-                },
-                "has-symbols": {
-                    "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-                    "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
-                },
-                "is-callable": {
-                    "version": "1.2.3",
-                    "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
-                    "integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ=="
-                },
-                "is-regex": {
-                    "version": "1.1.2",
-                    "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
-                    "integrity": "sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==",
-                    "requires": {
-                        "call-bind": "^1.0.2",
-                        "has-symbols": "^1.0.1"
-                    }
-                },
-                "object-inspect": {
-                    "version": "1.9.0",
-                    "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
-                    "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw=="
-                }
             }
         },
         "is-typedarray": {
@@ -10264,9 +10225,9 @@
             }
         },
         "mock-fs": {
-            "version": "4.13.0",
-            "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.13.0.tgz",
-            "integrity": "sha512-DD0vOdofJdoaRNtnWcrXe6RQbpHkPPmtqGq14uRX0F8ZKJ5nv89CVTYl/BZdppDxBDaV0hl75htg3abpEWlPZA=="
+            "version": "4.14.0",
+            "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.14.0.tgz",
+            "integrity": "sha512-qYvlv/exQ4+svI3UOvPUpLDF0OMX5euvUH0Ny4N5QyRyhNdgAgUrVH3iUINSzEPLvx0kbo/Bp28GJKIqvE7URw=="
         },
         "mongodb": {
             "version": "3.6.5",
@@ -10650,9 +10611,9 @@
             }
         },
         "node-releases": {
-            "version": "1.1.71",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.71.tgz",
-            "integrity": "sha512-zR6HoT6LrLCRBwukmrVbHv0EpEQjksO6GmFcZQQuCAy139BEsoVKPYnf3jongYW83fAa1torLGYwxxky/p28sg==",
+            "version": "1.1.72",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.72.tgz",
+            "integrity": "sha512-LLUo+PpH3dU6XizX3iVoubUNheF/owjXCZZ5yACDxNnPtgFuludV1ZL3ayK1kVep42Rmm0+R9/Y60NQbZ2bifw==",
             "dev": true
         },
         "node-sass": {
@@ -10930,13 +10891,6 @@
                 "define-properties": "^1.1.3",
                 "has-symbols": "^1.0.1",
                 "object-keys": "^1.1.1"
-            },
-            "dependencies": {
-                "has-symbols": {
-                    "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-                    "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
-                }
             }
         },
         "object.pick": {
@@ -12902,7 +12856,6 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-            "dev": true,
             "requires": {
                 "safe-buffer": "~5.1.0"
             }
@@ -13678,13 +13631,6 @@
                 "has-bigints": "^1.0.1",
                 "has-symbols": "^1.0.2",
                 "which-boxed-primitive": "^1.0.2"
-            },
-            "dependencies": {
-                "has-symbols": {
-                    "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-                    "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
-                }
             }
         },
         "undefsafe": {
@@ -13697,9 +13643,9 @@
             }
         },
         "underscore": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
-            "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
+            "version": "1.12.1",
+            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
+            "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw=="
         },
         "union-value": {
             "version": "1.0.1",
@@ -13883,9 +13829,9 @@
             "dev": true
         },
         "utf-8-validate": {
-            "version": "5.0.4",
-            "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.4.tgz",
-            "integrity": "sha512-MEF05cPSq3AwJ2C7B7sHAA6i53vONoZbMGX8My5auEVm6W+dJ2Jd/TZPyGJ5CH42V2XtbI5FD28HeHeqlPzZ3Q==",
+            "version": "5.0.5",
+            "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.5.tgz",
+            "integrity": "sha512-+pnxRYsS/axEpkrrEpzYfNZGXp0IjC/9RIxwM5gntY4Koi8SHmUGSfxfWqxZdRxrtaoVstuOzUp/rbs3JSPELQ==",
             "requires": {
                 "node-gyp-build": "^4.2.0"
             }
@@ -14016,189 +13962,158 @@
             }
         },
         "web3": {
-            "version": "1.3.5",
-            "resolved": "https://registry.npmjs.org/web3/-/web3-1.3.5.tgz",
-            "integrity": "sha512-UyQW/MT5EIGBrXPCh/FDIaD7RtJTn5/rJUNw2FOglp0qoXnCQHNKvntiR1ylztk05fYxIF6UgsC76IrazlKJjw==",
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/web3/-/web3-1.3.6.tgz",
+            "integrity": "sha512-jEpPhnL6GDteifdVh7ulzlPrtVQeA30V9vnki9liYlUvLV82ZM7BNOQJiuzlDePuE+jZETZSP/0G/JlUVt6pOA==",
             "requires": {
-                "web3-bzz": "1.3.5",
-                "web3-core": "1.3.5",
-                "web3-eth": "1.3.5",
-                "web3-eth-personal": "1.3.5",
-                "web3-net": "1.3.5",
-                "web3-shh": "1.3.5",
-                "web3-utils": "1.3.5"
+                "web3-bzz": "1.3.6",
+                "web3-core": "1.3.6",
+                "web3-eth": "1.3.6",
+                "web3-eth-personal": "1.3.6",
+                "web3-net": "1.3.6",
+                "web3-shh": "1.3.6",
+                "web3-utils": "1.3.6"
             }
         },
         "web3-bzz": {
-            "version": "1.3.5",
-            "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.3.5.tgz",
-            "integrity": "sha512-XiEUAbB1uKm/agqfwBsCW8fbw+sma85TfwuDpdcy591vinVk0S9TfWgLxro6v1KJ6nSELySIbKGbAJbh2GSyxw==",
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.3.6.tgz",
+            "integrity": "sha512-ibHdx1wkseujFejrtY7ZyC0QxQ4ATXjzcNUpaLrvM6AEae8prUiyT/OloG9FWDgFD2CPLwzKwfSQezYQlANNlw==",
             "requires": {
                 "@types/node": "^12.12.6",
                 "got": "9.6.0",
                 "swarm-js": "^0.1.40",
-                "underscore": "1.9.1"
+                "underscore": "1.12.1"
             },
             "dependencies": {
                 "@types/node": {
-                    "version": "12.20.7",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.7.tgz",
-                    "integrity": "sha512-gWL8VUkg8VRaCAUgG9WmhefMqHmMblxe2rVpMF86nZY/+ZysU+BkAp+3cz03AixWDSSz0ks5WX59yAhv/cDwFA=="
-                },
-                "got": {
-                    "version": "9.6.0",
-                    "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
-                    "integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
-                    "requires": {
-                        "@sindresorhus/is": "^0.14.0",
-                        "@szmarczak/http-timer": "^1.1.2",
-                        "cacheable-request": "^6.0.0",
-                        "decompress-response": "^3.3.0",
-                        "duplexer3": "^0.1.4",
-                        "get-stream": "^4.1.0",
-                        "lowercase-keys": "^1.0.1",
-                        "mimic-response": "^1.0.1",
-                        "p-cancelable": "^1.0.0",
-                        "to-readable-stream": "^1.0.0",
-                        "url-parse-lax": "^3.0.0"
-                    }
-                },
-                "prepend-http": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
-                    "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
-                },
-                "url-parse-lax": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
-                    "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
-                    "requires": {
-                        "prepend-http": "^2.0.0"
-                    }
+                    "version": "12.20.13",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.13.tgz",
+                    "integrity": "sha512-1x8W5OpxPq+T85OUsHRP6BqXeosKmeXRtjoF39STcdf/UWLqUsoehstZKOi0CunhVqHG17AyZgpj20eRVooK6A=="
                 }
             }
         },
         "web3-core": {
-            "version": "1.3.5",
-            "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.3.5.tgz",
-            "integrity": "sha512-VQjTvnGTqJwDwjKEHSApea3RmgtFGLDSJ6bqrOyHROYNyTyKYjFQ/drG9zs3rjDkND9mgh8foI1ty37Qua3QCQ==",
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.3.6.tgz",
+            "integrity": "sha512-gkLDM4T1Sc0T+HZIwxrNrwPg0IfWI0oABSglP2X5ZbBAYVUeEATA0o92LWV8BeF+okvKXLK1Fek/p6axwM/h3Q==",
             "requires": {
                 "@types/bn.js": "^4.11.5",
                 "@types/node": "^12.12.6",
                 "bignumber.js": "^9.0.0",
-                "web3-core-helpers": "1.3.5",
-                "web3-core-method": "1.3.5",
-                "web3-core-requestmanager": "1.3.5",
-                "web3-utils": "1.3.5"
+                "web3-core-helpers": "1.3.6",
+                "web3-core-method": "1.3.6",
+                "web3-core-requestmanager": "1.3.6",
+                "web3-utils": "1.3.6"
             },
             "dependencies": {
                 "@types/node": {
-                    "version": "12.20.7",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.7.tgz",
-                    "integrity": "sha512-gWL8VUkg8VRaCAUgG9WmhefMqHmMblxe2rVpMF86nZY/+ZysU+BkAp+3cz03AixWDSSz0ks5WX59yAhv/cDwFA=="
+                    "version": "12.20.13",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.13.tgz",
+                    "integrity": "sha512-1x8W5OpxPq+T85OUsHRP6BqXeosKmeXRtjoF39STcdf/UWLqUsoehstZKOi0CunhVqHG17AyZgpj20eRVooK6A=="
                 }
             }
         },
         "web3-core-helpers": {
-            "version": "1.3.5",
-            "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.3.5.tgz",
-            "integrity": "sha512-HYh3ix5FjysgT0jyzD8s/X5ym0b4BGU7I2QtuBiydMnE0mQEWy7GcT9XKpTySA8FTOHHIAQYvQS07DN/ky3UzA==",
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.3.6.tgz",
+            "integrity": "sha512-nhtjA2ZbkppjlxTSwG0Ttu6FcPkVu1rCN5IFAOVpF/L0SEt+jy+O5l90+cjDq0jAYvlBwUwnbh2mR9hwDEJCNA==",
             "requires": {
-                "underscore": "1.9.1",
-                "web3-eth-iban": "1.3.5",
-                "web3-utils": "1.3.5"
+                "underscore": "1.12.1",
+                "web3-eth-iban": "1.3.6",
+                "web3-utils": "1.3.6"
             }
         },
         "web3-core-method": {
-            "version": "1.3.5",
-            "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.3.5.tgz",
-            "integrity": "sha512-hCbmgQ+At6OTuaNGAdjXMsCr4eUCmp9yGKSuaB5HdkNVDpqFso4HHjVxcjNrTyJp3OZnyjKBzQzK1ZWLpLl84Q==",
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.3.6.tgz",
+            "integrity": "sha512-RyegqVGxn0cyYW5yzAwkPlsSEynkdPiegd7RxgB4ak1eKk2Cv1q2x4C7D2sZjeeCEF+q6fOkVmo2OZNqS2iQxg==",
             "requires": {
                 "@ethersproject/transactions": "^5.0.0-beta.135",
-                "underscore": "1.9.1",
-                "web3-core-helpers": "1.3.5",
-                "web3-core-promievent": "1.3.5",
-                "web3-core-subscriptions": "1.3.5",
-                "web3-utils": "1.3.5"
+                "underscore": "1.12.1",
+                "web3-core-helpers": "1.3.6",
+                "web3-core-promievent": "1.3.6",
+                "web3-core-subscriptions": "1.3.6",
+                "web3-utils": "1.3.6"
             }
         },
         "web3-core-promievent": {
-            "version": "1.3.5",
-            "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.3.5.tgz",
-            "integrity": "sha512-K0j8x3ZJr0eAyNvyUCxOUsSTd4hco0/9nxxlyOuijcsa6YV8l9NL6eqhniWbSyxCJT8ka5Mb7yAiUZe69EDLBQ==",
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.3.6.tgz",
+            "integrity": "sha512-Z+QzfyYDTXD5wJmZO5wwnRO8bAAHEItT1XNSPVb4J1CToV/I/SbF7CuF8Uzh2jns0Cm1109o666H7StFFvzVKw==",
             "requires": {
                 "eventemitter3": "4.0.4"
             }
         },
         "web3-core-requestmanager": {
-            "version": "1.3.5",
-            "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.3.5.tgz",
-            "integrity": "sha512-9l294U3Ga8qmvv8E37BqjQREfMs+kFnkU3PY28g9DZGYzKvl3V1dgDYqxyrOBdCFhc7rNSpHdgC4PrVHjouspg==",
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.3.6.tgz",
+            "integrity": "sha512-2rIaeuqeo7QN1Eex7aXP0ZqeteJEPWXYFS/M3r3LXMiV8R4STQBKE+//dnHJXoo2ctzEB5cgd+7NaJM8S3gPyA==",
             "requires": {
-                "underscore": "1.9.1",
+                "underscore": "1.12.1",
                 "util": "^0.12.0",
-                "web3-core-helpers": "1.3.5",
-                "web3-providers-http": "1.3.5",
-                "web3-providers-ipc": "1.3.5",
-                "web3-providers-ws": "1.3.5"
+                "web3-core-helpers": "1.3.6",
+                "web3-providers-http": "1.3.6",
+                "web3-providers-ipc": "1.3.6",
+                "web3-providers-ws": "1.3.6"
             }
         },
         "web3-core-subscriptions": {
-            "version": "1.3.5",
-            "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.3.5.tgz",
-            "integrity": "sha512-6mtXdaEB1V1zKLqYBq7RF2W75AK5ZJNGpW6QYC7Zvbku7zq1ZlgaUkJo88JKMWJ7etfaHaYqQ/7VveHk5sQynA==",
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.3.6.tgz",
+            "integrity": "sha512-wi9Z9X5X75OKvxAg42GGIf81ttbNR2TxzkAsp1g+nnp5K8mBwgZvXrIsDuj7Z7gx72Y45mWJADCWjk/2vqNu8g==",
             "requires": {
                 "eventemitter3": "4.0.4",
-                "underscore": "1.9.1",
-                "web3-core-helpers": "1.3.5"
+                "underscore": "1.12.1",
+                "web3-core-helpers": "1.3.6"
             }
         },
         "web3-eth": {
-            "version": "1.3.5",
-            "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.3.5.tgz",
-            "integrity": "sha512-5qqDPMMD+D0xRqOV2ePU2G7/uQmhn0FgCEhFzKDMHrssDQJyQLW/VgfA0NLn64lWnuUrGnQStGvNxrWf7MgsfA==",
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.3.6.tgz",
+            "integrity": "sha512-9+rnywRRpyX3C4hfsAQXPQh6vHh9XzQkgLxo3gyeXfbhbShUoq2gFVuy42vsRs//6JlsKdyZS7Z3hHPHz2wreA==",
             "requires": {
-                "underscore": "1.9.1",
-                "web3-core": "1.3.5",
-                "web3-core-helpers": "1.3.5",
-                "web3-core-method": "1.3.5",
-                "web3-core-subscriptions": "1.3.5",
-                "web3-eth-abi": "1.3.5",
-                "web3-eth-accounts": "1.3.5",
-                "web3-eth-contract": "1.3.5",
-                "web3-eth-ens": "1.3.5",
-                "web3-eth-iban": "1.3.5",
-                "web3-eth-personal": "1.3.5",
-                "web3-net": "1.3.5",
-                "web3-utils": "1.3.5"
+                "underscore": "1.12.1",
+                "web3-core": "1.3.6",
+                "web3-core-helpers": "1.3.6",
+                "web3-core-method": "1.3.6",
+                "web3-core-subscriptions": "1.3.6",
+                "web3-eth-abi": "1.3.6",
+                "web3-eth-accounts": "1.3.6",
+                "web3-eth-contract": "1.3.6",
+                "web3-eth-ens": "1.3.6",
+                "web3-eth-iban": "1.3.6",
+                "web3-eth-personal": "1.3.6",
+                "web3-net": "1.3.6",
+                "web3-utils": "1.3.6"
             }
         },
         "web3-eth-abi": {
-            "version": "1.3.5",
-            "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.3.5.tgz",
-            "integrity": "sha512-bkbG2v/mOW5DH6rF/SEgqunusjYoEi2IBw+fkmD3rzWDaEY7+/i1xY94AeO257d06QMgld75GtV/N+aEs7A6vQ==",
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.3.6.tgz",
+            "integrity": "sha512-Or5cRnZu6WzgScpmbkvC6bfNxR26hqiKK4i8sMPFeTUABQcb/FU3pBj7huBLYbp9dH+P5W79D2MqwbWwjj9DoQ==",
             "requires": {
                 "@ethersproject/abi": "5.0.7",
-                "underscore": "1.9.1",
-                "web3-utils": "1.3.5"
+                "underscore": "1.12.1",
+                "web3-utils": "1.3.6"
             }
         },
         "web3-eth-accounts": {
-            "version": "1.3.5",
-            "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.3.5.tgz",
-            "integrity": "sha512-r3WOR21rgm6Cd6OFnifr3Tizdm5K+g2TsSOPySwX4FrgLrYDL6ck4zr5VXUPz+llpSExb/JztpE8pqEHr3U2NA==",
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.3.6.tgz",
+            "integrity": "sha512-Ilr0hG6ONbCdSlVKffasCmNwftD5HsNpwyQASevocIQwHdTlvlwO0tb3oGYuajbKOaDzNTwXfz25bttAEoFCGA==",
             "requires": {
                 "crypto-browserify": "3.12.0",
                 "eth-lib": "0.2.8",
                 "ethereumjs-common": "^1.3.2",
                 "ethereumjs-tx": "^2.1.1",
                 "scrypt-js": "^3.0.1",
-                "underscore": "1.9.1",
+                "underscore": "1.12.1",
                 "uuid": "3.3.2",
-                "web3-core": "1.3.5",
-                "web3-core-helpers": "1.3.5",
-                "web3-core-method": "1.3.5",
-                "web3-utils": "1.3.5"
+                "web3-core": "1.3.6",
+                "web3-core-helpers": "1.3.6",
+                "web3-core-method": "1.3.6",
+                "web3-utils": "1.3.6"
             },
             "dependencies": {
                 "eth-lib": {
@@ -14219,121 +14134,121 @@
             }
         },
         "web3-eth-contract": {
-            "version": "1.3.5",
-            "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.3.5.tgz",
-            "integrity": "sha512-WfGVeQquN3D7Qm+KEIN9EI7yrm/fL2V9Y4+YhDWiKA/ns1pX1LYcEWojTOnBXCnPF3tcvoKKL+KBxXg1iKm38A==",
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.3.6.tgz",
+            "integrity": "sha512-8gDaRrLF2HCg+YEZN1ov0zN35vmtPnGf3h1DxmJQK5Wm2lRMLomz9rsWsuvig3UJMHqZAQKD7tOl3ocJocQsmA==",
             "requires": {
                 "@types/bn.js": "^4.11.5",
-                "underscore": "1.9.1",
-                "web3-core": "1.3.5",
-                "web3-core-helpers": "1.3.5",
-                "web3-core-method": "1.3.5",
-                "web3-core-promievent": "1.3.5",
-                "web3-core-subscriptions": "1.3.5",
-                "web3-eth-abi": "1.3.5",
-                "web3-utils": "1.3.5"
+                "underscore": "1.12.1",
+                "web3-core": "1.3.6",
+                "web3-core-helpers": "1.3.6",
+                "web3-core-method": "1.3.6",
+                "web3-core-promievent": "1.3.6",
+                "web3-core-subscriptions": "1.3.6",
+                "web3-eth-abi": "1.3.6",
+                "web3-utils": "1.3.6"
             }
         },
         "web3-eth-ens": {
-            "version": "1.3.5",
-            "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.3.5.tgz",
-            "integrity": "sha512-5bkpFTXV18CvaVP8kCbLZZm2r1TWUv9AsXH+80yz8bTZulUGvXsBMRfK6e5nfEr2Yv59xlIXCFoalmmySI9EJw==",
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.3.6.tgz",
+            "integrity": "sha512-n27HNj7lpSkRxTgSx+Zo7cmKAgyg2ElFilaFlUu/X2CNH23lXfcPm2bWssivH9z0ndhg0OyR4AYFZqPaqDHkJA==",
             "requires": {
                 "content-hash": "^2.5.2",
                 "eth-ens-namehash": "2.0.8",
-                "underscore": "1.9.1",
-                "web3-core": "1.3.5",
-                "web3-core-helpers": "1.3.5",
-                "web3-core-promievent": "1.3.5",
-                "web3-eth-abi": "1.3.5",
-                "web3-eth-contract": "1.3.5",
-                "web3-utils": "1.3.5"
+                "underscore": "1.12.1",
+                "web3-core": "1.3.6",
+                "web3-core-helpers": "1.3.6",
+                "web3-core-promievent": "1.3.6",
+                "web3-eth-abi": "1.3.6",
+                "web3-eth-contract": "1.3.6",
+                "web3-utils": "1.3.6"
             }
         },
         "web3-eth-iban": {
-            "version": "1.3.5",
-            "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.3.5.tgz",
-            "integrity": "sha512-x+BI/d2Vt0J1cKK8eFd4W0f1TDjgEOYCwiViTb28lLE+tqrgyPqWDA+l6UlKYLF/yMFX3Dym4ofcCOtgcn4q4g==",
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.3.6.tgz",
+            "integrity": "sha512-nfMQaaLA/zsg5W4Oy/EJQbs8rSs1vBAX6b/35xzjYoutXlpHMQadujDx2RerTKhSHqFXSJeQAfE+2f6mdhYkRQ==",
             "requires": {
                 "bn.js": "^4.11.9",
-                "web3-utils": "1.3.5"
+                "web3-utils": "1.3.6"
             }
         },
         "web3-eth-personal": {
-            "version": "1.3.5",
-            "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.3.5.tgz",
-            "integrity": "sha512-xELQHNZ8p3VoO1582ghCaq+Bx7pSkOOalc6/ACOCGtHDMelqgVejrmSIZGScYl+k0HzngmQAzURZWQocaoGM1g==",
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.3.6.tgz",
+            "integrity": "sha512-pOHU0+/h1RFRYoh1ehYBehRbcKWP4OSzd4F7mDljhHngv6W8ewMHrAN8O1ol9uysN2MuCdRE19qkRg5eNgvzFQ==",
             "requires": {
                 "@types/node": "^12.12.6",
-                "web3-core": "1.3.5",
-                "web3-core-helpers": "1.3.5",
-                "web3-core-method": "1.3.5",
-                "web3-net": "1.3.5",
-                "web3-utils": "1.3.5"
+                "web3-core": "1.3.6",
+                "web3-core-helpers": "1.3.6",
+                "web3-core-method": "1.3.6",
+                "web3-net": "1.3.6",
+                "web3-utils": "1.3.6"
             },
             "dependencies": {
                 "@types/node": {
-                    "version": "12.20.7",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.7.tgz",
-                    "integrity": "sha512-gWL8VUkg8VRaCAUgG9WmhefMqHmMblxe2rVpMF86nZY/+ZysU+BkAp+3cz03AixWDSSz0ks5WX59yAhv/cDwFA=="
+                    "version": "12.20.13",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.13.tgz",
+                    "integrity": "sha512-1x8W5OpxPq+T85OUsHRP6BqXeosKmeXRtjoF39STcdf/UWLqUsoehstZKOi0CunhVqHG17AyZgpj20eRVooK6A=="
                 }
             }
         },
         "web3-net": {
-            "version": "1.3.5",
-            "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.3.5.tgz",
-            "integrity": "sha512-usbFbuUpKK8s7jPLGoUzi/WpNnefGFPTj948aJv8BZ04UQA4L/XS5NNkkhk358zNMmhGfEFW8wrWy+0Oy0njtA==",
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.3.6.tgz",
+            "integrity": "sha512-KhzU3wMQY/YYjyMiQzbaLPt2kut88Ncx2iqjy3nw28vRux3gVX0WOCk9EL/KVJBiAA/fK7VklTXvgy9dZnnipw==",
             "requires": {
-                "web3-core": "1.3.5",
-                "web3-core-method": "1.3.5",
-                "web3-utils": "1.3.5"
+                "web3-core": "1.3.6",
+                "web3-core-method": "1.3.6",
+                "web3-utils": "1.3.6"
             }
         },
         "web3-providers-http": {
-            "version": "1.3.5",
-            "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.3.5.tgz",
-            "integrity": "sha512-ZQOmceFjcajEZdiuqciXjijwIYWNmEJ1oxMtbrwB2eGxHRCMXEH2xGRUZuhOFNF88yQC/VXVi14yvYg5ZlFJlA==",
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.3.6.tgz",
+            "integrity": "sha512-OQkT32O1A06dISIdazpGLveZcOXhEo5cEX6QyiSQkiPk/cjzDrXMw4SKZOGQbbS1+0Vjizm1Hrp7O8Vp2D1M5Q==",
             "requires": {
-                "web3-core-helpers": "1.3.5",
+                "web3-core-helpers": "1.3.6",
                 "xhr2-cookies": "1.1.0"
             }
         },
         "web3-providers-ipc": {
-            "version": "1.3.5",
-            "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.3.5.tgz",
-            "integrity": "sha512-cbZOeb/sALiHjzMolJjIyHla/J5wdL2JKUtRO66Nh/uLALBCpU8JUgzNvpAdJ1ae3+A33+EdFStdzuDYHKtQew==",
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.3.6.tgz",
+            "integrity": "sha512-+TVsSd2sSVvVgHG4s6FXwwYPPT91boKKcRuEFXqEfAbUC5t52XOgmyc2LNiD9LzPhed65FbV4LqICpeYGUvSwA==",
             "requires": {
                 "oboe": "2.1.5",
-                "underscore": "1.9.1",
-                "web3-core-helpers": "1.3.5"
+                "underscore": "1.12.1",
+                "web3-core-helpers": "1.3.6"
             }
         },
         "web3-providers-ws": {
-            "version": "1.3.5",
-            "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.3.5.tgz",
-            "integrity": "sha512-zeZ4LMvKhYaJBDCqA//Bzgp4r/T0tNq5U/xvN0axA4YflzF7yqlsbzGwCkcZYDbrUaK3Ltl2uOmvwjbWALOZ1A==",
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.3.6.tgz",
+            "integrity": "sha512-bk7MnJf5or0Re2zKyhR3L3CjGululLCHXx4vlbc/drnaTARUVvi559OI5uLytc/1k5HKUUyENAxLvetz2G1dnQ==",
             "requires": {
                 "eventemitter3": "4.0.4",
-                "underscore": "1.9.1",
-                "web3-core-helpers": "1.3.5",
+                "underscore": "1.12.1",
+                "web3-core-helpers": "1.3.6",
                 "websocket": "^1.0.32"
             }
         },
         "web3-shh": {
-            "version": "1.3.5",
-            "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.3.5.tgz",
-            "integrity": "sha512-aRwzCduXvuGVslLL/Y15VcOHa70Qr2kxZI7UwOzQVhaaOdxuRRvo3AK/cmyln1Tsd54/n93Yk8I3qg5I2+6alw==",
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.3.6.tgz",
+            "integrity": "sha512-9zRo415O0iBslxBnmu9OzYjNErzLnzOsy+IOvSpIreLYbbAw0XkDWxv3SfcpKnTIWIACBR4AYMIxmmyi5iB3jw==",
             "requires": {
-                "web3-core": "1.3.5",
-                "web3-core-method": "1.3.5",
-                "web3-core-subscriptions": "1.3.5",
-                "web3-net": "1.3.5"
+                "web3-core": "1.3.6",
+                "web3-core-method": "1.3.6",
+                "web3-core-subscriptions": "1.3.6",
+                "web3-net": "1.3.6"
             }
         },
         "web3-utils": {
-            "version": "1.3.5",
-            "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.3.5.tgz",
-            "integrity": "sha512-5apMRm8ElYjI/92GHqijmaLC+s+d5lgjpjHft+rJSs/dsnX8I8tQreqev0dmU+wzU+2EEe4Sx9a/OwGWHhQv3A==",
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.3.6.tgz",
+            "integrity": "sha512-hHatFaQpkQgjGVER17gNx8u1qMyaXFZtM0y0XLGH1bzsjMPlkMPLRcYOrZ00rOPfTEuYFOdrpGOqZXVmGrMZRg==",
             "requires": {
                 "bn.js": "^4.11.9",
                 "eth-lib": "0.2.8",
@@ -14341,7 +14256,7 @@
                 "ethjs-unit": "0.1.6",
                 "number-to-bn": "1.7.0",
                 "randombytes": "^2.1.0",
-                "underscore": "1.9.1",
+                "underscore": "1.12.1",
                 "utf8": "3.0.0"
             },
             "dependencies": {
@@ -14364,9 +14279,9 @@
             "dev": true
         },
         "websocket": {
-            "version": "1.0.33",
-            "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.33.tgz",
-            "integrity": "sha512-XwNqM2rN5eh3G2CUQE3OHZj+0xfdH42+OFK6LdC2yqiC0YU8e5UK0nYre220T0IyyN031V/XOvtHvXozvJYFWA==",
+            "version": "1.0.34",
+            "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.34.tgz",
+            "integrity": "sha512-PRDso2sGwF6kM75QykIesBijKSVceR6jL2G8NGYyq2XrItNC2P5/qL5XeR056GhA+Ly7JMFvJb9I312mJfmqnQ==",
             "requires": {
                 "bufferutil": "^4.0.1",
                 "debug": "^2.2.0",
@@ -14421,21 +14336,6 @@
                 "is-number-object": "^1.0.4",
                 "is-string": "^1.0.5",
                 "is-symbol": "^1.0.3"
-            },
-            "dependencies": {
-                "has-symbols": {
-                    "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-                    "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
-                },
-                "is-symbol": {
-                    "version": "1.0.3",
-                    "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
-                    "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
-                    "requires": {
-                        "has-symbols": "^1.0.1"
-                    }
-                }
             }
         },
         "which-module": {
@@ -14456,65 +14356,6 @@
                 "function-bind": "^1.1.1",
                 "has-symbols": "^1.0.1",
                 "is-typed-array": "^1.1.3"
-            },
-            "dependencies": {
-                "es-abstract": {
-                    "version": "1.18.0",
-                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0.tgz",
-                    "integrity": "sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==",
-                    "requires": {
-                        "call-bind": "^1.0.2",
-                        "es-to-primitive": "^1.2.1",
-                        "function-bind": "^1.1.1",
-                        "get-intrinsic": "^1.1.1",
-                        "has": "^1.0.3",
-                        "has-symbols": "^1.0.2",
-                        "is-callable": "^1.2.3",
-                        "is-negative-zero": "^2.0.1",
-                        "is-regex": "^1.1.2",
-                        "is-string": "^1.0.5",
-                        "object-inspect": "^1.9.0",
-                        "object-keys": "^1.1.1",
-                        "object.assign": "^4.1.2",
-                        "string.prototype.trimend": "^1.0.4",
-                        "string.prototype.trimstart": "^1.0.4",
-                        "unbox-primitive": "^1.0.0"
-                    }
-                },
-                "es-to-primitive": {
-                    "version": "1.2.1",
-                    "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
-                    "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-                    "requires": {
-                        "is-callable": "^1.1.4",
-                        "is-date-object": "^1.0.1",
-                        "is-symbol": "^1.0.2"
-                    }
-                },
-                "has-symbols": {
-                    "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-                    "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
-                },
-                "is-callable": {
-                    "version": "1.2.3",
-                    "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
-                    "integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ=="
-                },
-                "is-regex": {
-                    "version": "1.1.2",
-                    "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
-                    "integrity": "sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==",
-                    "requires": {
-                        "call-bind": "^1.0.2",
-                        "has-symbols": "^1.0.1"
-                    }
-                },
-                "object-inspect": {
-                    "version": "1.9.0",
-                    "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
-                    "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw=="
-                }
             }
         },
         "wide-align": {
@@ -14790,6 +14631,16 @@
                 "is-typedarray": "^1.0.0",
                 "signal-exit": "^3.0.2",
                 "typedarray-to-buffer": "^3.1.5"
+            }
+        },
+        "ws": {
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
+            "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
+            "requires": {
+                "async-limiter": "~1.0.0",
+                "safe-buffer": "~5.1.0",
+                "ultron": "~1.1.0"
             }
         },
         "xdg-basedir": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
         "pug": "^3.0.2",
         "typescript": "^4.2.4",
         "uuid": "^8.3.1",
-        "web3": "^1.3.5",
+        "web3": "^1.3.6",
         "winston": "^3.2.1",
         "winston-console-format": "^1.0.8"
     },


### PR DESCRIPTION
1. `npm audit fix` fixed 2 vulnerabilities:
    - browserslist - [Regular Expression Denial of Service](https://npmjs.com/advisories/1747)
    - hosted-git-info - [Regular Expression Denial of Service](https://npmjs.com/advisories/1677)

2. Manually updated package `web3` (`1.3.5` -> `1.3.6`), because `v1.3.5` uses `underscore` `v1.9.1` package, which is vulnerable to [Arbitrary Code Execution](https://www.npmjs.com/advisories/1674).
    `web3` `v1.3.6` has updated the `underscore` package to `v1.12.1` which fixes this vulnerability ([more information about `v1.3.6`](https://github.com/ChainSafe/web3.js/releases/tag/v1.3.6)).

3. Currently there is 1 remaining low severity vulnerability ([Insecure Credential Storage](https://www.npmjs.com/advisories/877)) that does not have a fix available.